### PR TITLE
Refactor keychain item password retrieval functions

### DIFF
--- a/Private/MacOS/Get-MacOSKeychainItem.ps1
+++ b/Private/MacOS/Get-MacOSKeychainItem.ps1
@@ -40,7 +40,7 @@ function Get-MacOSKeychainItem {
         
         $Username = $keychainItem.UserName
         # Use wrapper function to get password
-        $securePassword = Get-KeyChainPassword -Name $serviceName -Username $Username | ConvertTo-SecureString -AsPlainText
+        $securePassword = Get-KeyChainPassword -Name $keychainItem.Name -Username $keychainItem.UserName
         
         # Return standardized credential object
         $objParams = @{

--- a/Private/MacOS/MacOS-KeychainWrapper.ps1
+++ b/Private/MacOS/MacOS-KeychainWrapper.ps1
@@ -236,7 +236,7 @@ function Get-KeychainPassword {
         if ($passwordPlain -is [array]) {
             $passwordPlain = $passwordPlain -join ''
         }
-        $passwordPlain = $passwordPlain.ToString().Trim()
+        $passwordPlain = $passwordPlain.Trim()
         
         # Convert plain text password to SecureString
         if ([string]::IsNullOrEmpty($passwordPlain)) {

--- a/Private/MacOS/MacOS-KeychainWrapper.ps1
+++ b/Private/MacOS/MacOS-KeychainWrapper.ps1
@@ -236,7 +236,7 @@ function Get-KeychainPassword {
         if ($passwordPlain -is [array]) {
             $passwordPlain = $passwordPlain -join ''
         }
-        $passwordPlain = $passwordPlain.Trim()
+        $passwordPlain = ([string]$passwordPlain).Trim()
         
         # Convert plain text password to SecureString
         if ([string]::IsNullOrEmpty($passwordPlain)) {

--- a/Private/MacOS/New-MacOSKeychainItem.ps1
+++ b/Private/MacOS/New-MacOSKeychainItem.ps1
@@ -34,7 +34,7 @@ function New-MacOSKeychainItem {
         Set-KeyChainEntry -Username $Username -Name $serviceName -Password $Password -Comment $Comment -Description 'PoShCredential'
         
         # Get final password for return object
-        $finalPassword = Get-KeyChainPassword -Name $serviceName -Username $Username | ConvertTo-SecureString -AsPlainText
+        $finalPassword = Get-KeyChainPassword -Name $serviceName -Username $Username
         
         # Return standardized credential object
         $objParams = @{


### PR DESCRIPTION
Refactor `Get-MacOSKeychainItem` and `New-MacOSKeychainItem` to directly use keychain item properties for password retrieval, improving clarity and efficiency.